### PR TITLE
fix: update input text on opening another bubble

### DIFF
--- a/src/AskString.tsx
+++ b/src/AskString.tsx
@@ -30,6 +30,14 @@ export default class AskString extends React.Component<Props, State> {
         };
     }
 
+    componentDidUpdate(prevProps: Props) {
+        if (prevProps.defaultValue !== this.props.defaultValue) {
+            this.setState({
+                value: this.props.defaultValue,
+            });
+        }
+    }
+
     public render(): React.ReactNode {
         const { type } = this.props;
         return (


### PR DESCRIPTION
@captain-igloo Thanks for the react implementation of an XML Edit plugin. I found an issue in the latest release, i have added a possible fix in this PR. Could you please review and merge this PR if this is a viable solution. Thanks.

Issue:
When we open a bubble when anther bubble is already open, the newly opened bubble will have the value of the previously open bubble. 

Fix:
Update the value when bubble is opened again.

Before:
![CPT2206191446-506x329](https://user-images.githubusercontent.com/13431142/174474080-45a10538-7e99-43b3-8855-e3275fe984b0.gif)

After:
![CPT2206191448-506x329](https://user-images.githubusercontent.com/13431142/174474147-45f60418-4aec-48e8-a4bf-d91d4595e3b9.gif)